### PR TITLE
fix: poetry's installation script

### DIFF
--- a/ansible/roles/poetry/tasks/main.yml
+++ b/ansible/roles/poetry/tasks/main.yml
@@ -7,8 +7,8 @@
   ansible.builtin.shell: |
     gosu ${NB_USER} bash <<'EOS'
 
-    curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
+    curl -sSL https://install.python-poetry.org | python3 -
 
-    echo 'command -v poetry >/dev/null || export PATH="${HOME}/.poetry/bin:${PATH}"' >> ~/.bashrc
+    echo 'command -v poetry >/dev/null || export PATH="${HOME}/.local/bin:${PATH}"' >> ~/.bashrc
 
     EOS


### PR DESCRIPTION
## What?
Fix poetry's installation script

## Why?
The previous method is deprecated

## See also [Optional]
https://python-poetry.org/docs/
